### PR TITLE
Allow to specify the ssh port for scp command

### DIFF
--- a/etc/smashbox.conf.template
+++ b/etc/smashbox.conf.template
@@ -123,3 +123,7 @@ del os
 # set it to True or False to override
 # 
 pycurl_verbose = None
+
+#
+# scp port to be used in scp commands, used primarily when copying over the server log file
+scp_port=22

--- a/python/smashbox/utilities/__init__.py
+++ b/python/smashbox/utilities/__init__.py
@@ -478,7 +478,7 @@ def scrape_log_file(d):
     :param d: The directory where the server log file is to be copied to
 
     """
-    cmd = 'scp root@%s:%s/owncloud.log %s/.' % (config.oc_server, config.oc_server_datadirectory, d)
+    cmd = 'scp -P %d root@%s:%s/owncloud.log %s/.' % (config.scp_port, config.oc_server, config.oc_server_datadirectory, d)
     rtn_code = runcmd(cmd)
 
     logger.info('copy command returned %s', rtn_code)


### PR DESCRIPTION
This adds the option `scp_port` to the smashbox.conf
