### PR TITLE
Worker must return error code when errors detected

### DIFF
--- a/python/smashbox/multiprocessing_engine.py
+++ b/python/smashbox/multiprocessing_engine.py
@@ -171,6 +171,8 @@ class _smash_:
             import smashbox.utilities
             if smashbox.utilities.reported_errors:
                logger.error('%s error(s) reported',len(smashbox.utilities.reported_errors))
+               import sys
+               sys.exit(2)
                   
 
     @staticmethod


### PR DESCRIPTION
This is needed, so CI systems can detect failures and errors and display test states accordingly.

Cherry picked from owncloud/smashbox#96
Fix owncloud/smashbox#95
Fix owncloud/smashbox#63
