### PR TITLE
Share group test does not reset accounts correctly

### DIFF
--- a/lib/oc-tests/test_shareGroup.py
+++ b/lib/oc-tests/test_shareGroup.py
@@ -82,7 +82,7 @@ OCS_PERMISSION_ALL = 31
 def setup(step):
 
     step (1, 'create test users')
-    reset_owncloud_account(config.oc_number_test_users)
+    reset_owncloud_account(num_test_users=config.oc_number_test_users)
     check_users(num_test_users=config.oc_number_test_users)
 
     reset_owncloud_group(num_groups=config.oc_number_test_groups)

--- a/lib/oc-tests/test_shareGroup.py
+++ b/lib/oc-tests/test_shareGroup.py
@@ -88,7 +88,9 @@ def setup(step):
     reset_owncloud_group(num_groups=config.oc_number_test_groups)
     check_groups(config.oc_number_test_groups)
 
-    add_user_to_group('user3', 'testgroup1')
+    user3 = "%s%i"%(config.oc_account_name, 3)
+    group1 = "%s%i"%(config.oc_group_name, 1)
+    add_user_to_group(user3, group1)
 
     reset_rundir()
 
@@ -258,7 +260,10 @@ def admin(step):
 
 
     step (14, 'Admin user removes user from group')
-    remove_user_from_group('user3', 'testgroup1')
+
+    user3 = "%s%i"%(config.oc_account_name, 3)
+    group1 = "%s%i"%(config.oc_group_name, 1)
+    add_user_to_group(user3, group1)
 
     step (16, 'Admin final step')
 

--- a/lib/oc-tests/test_shareGroup.py
+++ b/lib/oc-tests/test_shareGroup.py
@@ -263,7 +263,7 @@ def admin(step):
 
     user3 = "%s%i"%(config.oc_account_name, 3)
     group1 = "%s%i"%(config.oc_group_name, 1)
-    add_user_to_group(user3, group1)
+    remove_user_from_group(user3, group1)
 
     step (16, 'Admin final step')
 

--- a/python/smashbox/utilities/__init__.py
+++ b/python/smashbox/utilities/__init__.py
@@ -37,11 +37,11 @@ def reset_owncloud_account(reset_procedure=None, num_test_users=None):
         logger.info('reset_owncloud_account (%s) for %d users', reset_procedure, num_test_users)
 
     if reset_procedure == 'delete':
-        if num_test_users is None:
-            delete_owncloud_account(config.oc_account_name)
-            create_owncloud_account(config.oc_account_name, config.oc_account_password)
-            login_owncloud_account(config.oc_account_name, config.oc_account_password)
-        else:
+        delete_owncloud_account(config.oc_account_name)
+        create_owncloud_account(config.oc_account_name, config.oc_account_password)
+        login_owncloud_account(config.oc_account_name, config.oc_account_password)
+
+        if num_test_users is not None:
             for i in range(1, num_test_users + 1):
                 username = "%s%i" % (config.oc_account_name, i)
                 delete_owncloud_account(username)


### PR DESCRIPTION
The test fails when it is the first test that is run on a freshly set up oC instance:
- test user was not created but used
- The users test1-test3 are not created

The test fails when config settings are different:
- `config.oc_account_name` and `config.oc_group_name` were ignored

And the test always fails in the end:
- The user was not removed from the group, but tried to be added again

Cherry-picked from
owncloud/smashbox#73
owncloud/smashbox#106

@moscicki 
