### PR TITLE
Failed sharing checked incorrectly

### DIFF
--- a/lib/oc-tests/test_shareFile.py
+++ b/lib/oc-tests/test_shareFile.py
@@ -124,7 +124,7 @@ def sharer(step):
     step (7, 'Sharer validates modified file')
     run_ocsync(d,user_num=1)
 
-    if sharePermissions == (OCS_PERMISSION_READ | OCS_PERMISSION_SHARE):
+    if not sharePermissions & OCS_PERMISSION_UPDATE:
       expect_not_modified(os.path.join(d,'TEST_FILE_MODIFIED_USER_SHARE.dat'), shared['md5_sharer'])
     else:
       expect_modified(os.path.join(d,'TEST_FILE_MODIFIED_USER_SHARE.dat'), shared['md5_sharer'])
@@ -171,7 +171,7 @@ def shareeOne(step):
     list_files(d)
 
     shared = reflection.getSharedObject()
-    if sharePermissions == (OCS_PERMISSION_READ | OCS_PERMISSION_SHARE):
+    if not sharePermissions & OCS_PERMISSION_UPDATE:
       expect_not_modified(os.path.join(d,'TEST_FILE_MODIFIED_USER_SHARE.dat'), shared['md5_sharer'])
 
     step (8, 'Sharee One share files with user 3')
@@ -181,7 +181,7 @@ def shareeOne(step):
     kwargs = {'perms': sharePermissions}
     result = share_file_with_user ('TEST_FILE_USER_RESHARE.dat', user2, user3, **kwargs)
 
-    if sharePermissions == (OCS_PERMISSION_READ | OCS_PERMISSION_UPDATE):
+    if not sharePermissions & OCS_PERMISSION_SHARE:
       error_check (result == -1, "shared and shouldn't have")
 
     step (11, 'Sharee one validates file does not exist after unsharing')
@@ -217,7 +217,7 @@ def shareeTwo(step):
 
     sharedFile = os.path.join(d,'TEST_FILE_USER_RESHARE.dat')
 
-    if sharePermissions == (OCS_PERMISSION_READ | OCS_PERMISSION_UPDATE):
+    if not sharePermissions & OCS_PERMISSION_SHARE:
       logger.info ('Checking that %s is not present in local directory for Sharee Two', sharedFile)
       error_check(not os.path.exists(sharedFile), "File %s should not exist" %sharedFile)
     else:

--- a/lib/oc-tests/test_shareFile.py
+++ b/lib/oc-tests/test_shareFile.py
@@ -120,6 +120,7 @@ def sharer(step):
     shared['TEST_FILE_USER_SHARE'] = share_file_with_user ('TEST_FILE_USER_SHARE.dat', user1, user2, **kwargs)
     shared['TEST_FILE_USER_RESHARE'] = share_file_with_user ('TEST_FILE_USER_RESHARE.dat', user1, user2, **kwargs)
     shared['TEST_FILE_MODIFIED_USER_SHARE'] = share_file_with_user ('TEST_FILE_MODIFIED_USER_SHARE.dat', user1, user2, **kwargs)
+    shared['sharer.TEST_FILE_MODIFIED_USER_SHARE'] = os.path.join(d,'TEST_FILE_MODIFIED_USER_SHARE.dat')
 
     step (7, 'Sharer validates modified file')
     run_ocsync(d,user_num=1)
@@ -172,7 +173,10 @@ def shareeOne(step):
 
     shared = reflection.getSharedObject()
     if not sharePermissions & OCS_PERMISSION_UPDATE:
-      expect_not_modified(os.path.join(d,'TEST_FILE_MODIFIED_USER_SHARE.dat'), shared['md5_sharer'])
+        # local file is modified, but not synced so the owner still has the right file
+        list_files(d)
+        expect_modified(os.path.join(d,'TEST_FILE_MODIFIED_USER_SHARE.dat'), shared['md5_sharer'])
+        expect_not_modified(shared['sharer.TEST_FILE_MODIFIED_USER_SHARE'], shared['md5_sharer'])
 
     step (8, 'Sharee One share files with user 3')
 

--- a/python/smashbox/utilities/__init__.py
+++ b/python/smashbox/utilities/__init__.py
@@ -563,6 +563,8 @@ def share_file_with_user(filename, sharer, sharee, **kwargs):
     :returns: share id of the created share
 
     """
+    from owncloud import ResponseError
+
     logger.info('%s is sharing file %s with user %s', sharer, filename, sharee)
 
     oc_api = get_oc_api()
@@ -572,12 +574,9 @@ def share_file_with_user(filename, sharer, sharee, **kwargs):
         share_info = oc_api.share_file_with_user(filename, sharee, **kwargs)
         logger.info('share id for file share is %s', str(share_info.share_id))
         return share_info.share_id
-    except Exception as err:
-
-        # TODO: this code is not the best - the goal is to trap a share not allowed error and return that error code
-
+    except ResponseError as err:
         logger.info('Share failed with %s', str(err))
-        if "not allowed to share" in str(err):
+        if "not allowed to share" in str(err.get_resource_body()):
             return -1
         else:
             return -2
@@ -678,7 +677,7 @@ def expect_modified(fn, md5):
 
 
 def expect_not_modified(fn, md5):
-    """ Compares tha tthe checksum of two files is the same
+    """ Compares that the checksum of two files is the same
     """
     actual_md5 = md5sum(fn)
     error_check(actual_md5 == md5,


### PR DESCRIPTION
Share return was checked incorrectly:
- `HTTP Status: 403` does not contain `not allowed to share`, pyocclient allows accessing the body of the message which we compare now with f6412ae
- Made the permission check to check for the required permission, to allow easier adding of new test cases 507775f
- Check that the owners file is not modified when editing is not allowed e778236

Fix owncloud/smashbox#82
Cherry-picked from owncloud/smashbox#83

@moscicki 
