### PR TITLE
Fix sync and comparison logic test filenames.py

### DIFF
--- a/lib/test_filenames.py
+++ b/lib/test_filenames.py
@@ -1,4 +1,5 @@
-from smashbox.utilities import * 
+from smashbox.utilities import *
+from smashbox.utilities.hash_files import get_files
 from smashbox.utilities.hash_files import count_files
 
 import os
@@ -106,7 +107,7 @@ def creator(step):
             filenames.append(nn)
             createfile(os.path.join(d,nn),'1',count=filesizeKB,bs=1000)
 
-    files_1 = os.listdir(d)
+    files_1 = get_files(d)
     N = count_files(d)
 
     shared = reflection.getSharedObject()
@@ -119,10 +120,13 @@ def creator(step):
         run_ocsync(d)
         error_check(count_files(d) == N, "some files lost!")
 
-    files_2 = os.listdir(d)
+    files_2 = get_files(d)
 
     for fn in set(files_1)-set(files_2):
         error_check(False, "the file has disappeared: %s"%repr(fn))
+
+    for fn in set(files_2)-set(files_1):
+        error_check(False, "New file appeared: %s" % repr(fn))
 
 
 

--- a/lib/test_filenames.py
+++ b/lib/test_filenames.py
@@ -62,6 +62,7 @@ def creator(step):
     step(1,'create initial content and sync')
 
     d = make_workdir()
+    run_ocsync(d)
 
     namepatterns = [
         "space1 testfile.dat",

--- a/python/smashbox/utilities/hash_files.py
+++ b/python/smashbox/utilities/hash_files.py
@@ -27,14 +27,22 @@ BLOCK_SIZE = 1024*1024
 import os
 import fnmatch
 
-def count_files(wdir,filemask=None):
+
+def get_files(wdir, filemask=None):
     fl = os.listdir(wdir)
     # if filemask defined then filter names out accordingly
     if filemask:
-        fl = fnmatch.filter(fl,filemask.replace('{md5}','*'))
-    nf = len(set(fl) - set(config.ignored_files))
-    logger.info('%s: %d files found',wdir,nf)
+        fl = fnmatch.filter(fl, filemask.replace('{md5}', '*'))
+    fl = set(fl) - set(config.ignored_files)
+    return fl
+
+
+def count_files(wdir, filemask=None):
+    fl = get_files(wdir, filemask)
+    nf = len(fl)
+    logger.info('%s: %d files found', wdir, nf)
     return nf
+
 
 def size2nbytes(size):
     """ Return the number of bytes from the size specification (size may be a distribution or nbytes directly).


### PR DESCRIPTION
- A sync in the beginning was missing to make sure the skeleton files don't screw up the syncing
- `os.listdir()` did not ignore sync client related files and therefor generated false positives
- Split count_files into count_files and get_files to allow getting the list without client files
- Also outputting additional files (because they also make the "count files"-comparison fail

@moscicki 
