### PR TITLE
Fix basicSync_rmLocalStateDB in testcase 7

### DIFF
--- a/lib/test_basicSync.py
+++ b/lib/test_basicSync.py
@@ -49,7 +49,7 @@ testsets = [
           'basicSync_rmLocalStateDB':True
         },
         { 'basicSync_filesizeKB': 15000, 
-          'basicSync_rmLocalStateDB':False
+          'basicSync_rmLocalStateDB':True
         },
         { 'basicSync_filesizeKB': 50000, 
           'basicSync_rmLocalStateDB':True


### PR DESCRIPTION
I guess it doesn't make sense to run the same testcase twice, looks like a copy&paste error again

@moscicki 
