### PR TITLE
Output a warning to the log with fail information of the client

### DIFF
--- a/python/smashbox/utilities/__init__.py
+++ b/python/smashbox/utilities/__init__.py
@@ -270,8 +270,9 @@ def run_ocsync(local_folder, remote_folder="", n=None, user_num=None):
     for i in range(n):
         t0 = datetime.datetime.now()
         cmd = config.oc_sync_cmd+' '+local_folder+' '+oc_webdav_url('owncloud',remote_folder,user_num) + " >> "+config.rundir+"/%s-ocsync.step%02d.cnt%03d.log 2>&1"%(reflection.getProcessName(),current_step,ocsync_cnt[current_step])
-        runcmd(cmd, ignore_exitcode=True)  # exitcode of ocsync is not reliable
-        logger.info('sync cmd is: %s',cmd)
+        exitcode,stdout,stderr = runcmd(cmd, ignore_exitcode=True)  # exitcode of ocsync is not reliable
+        if exitcode != 0:
+            logger.warning('sync cmd failed(?) with exitcode: %d, stdout: %s, stderr: %s', exitcode, stdout, stderr)
         logger.info('sync finished: %s',datetime.datetime.now()-t0)
         ocsync_cnt[current_step]+=1
 


### PR DESCRIPTION
On a fresh set up it can take you a while to figure out you didn't set the right permissions on the directory, because the return code and messages are hidden:

Fix owncloud/smashbox#99

@moscicki 

I removed `logger.info('sync cmd is: %s',cmd)` because it is already written by runcmd:
https://github.com/owncloud/smashbox/blob/ee2b40f9995cf66f443ef00cb1ed7c14c4b69ab4/python/smashbox/utilities/__init__.py#L305-305

```
2015-06-25 10:15:40,493 - INFO - sharer - sync cmd is: ***/owncloudcmd --trust /var/lib/jenkins/build/smashdir/test_shareGroup/sharer/ ownclouds://***/owncloud8.1/remote.php/webdav/ >> ***/test_shareGroup/sharer-ocsync.step03.cnt000.log 2>&1
2015-06-25 10:15:40,493 - INFO - sharer - running '***/owncloudcmd --trust /var/lib/jenkins/build/smashdir/test_shareGroup/sharer/ ownclouds://***/owncloud8.1/remote.php/webdav/ >> ***/test_shareGroup/sharer-ocsync.step03.cnt000.log 2>&1'
2015-06-25 10:15:40,495 - WARNING - sharer - Non-zero exit code 1 from command '***/owncloudcmd --trust /var/lib/jenkins/build/smashdir/test_shareGroup/sharer/ ownclouds://***/owncloud8.1/remote.php/webdav/ >> ***/test_shareGroup/sharer-ocsync.step03.cnt000.log 2>&1'
```
