### PR TITLE
Better share group testing

### DIFF
--- a/lib/oc-tests/test_shareGroup.py
+++ b/lib/oc-tests/test_shareGroup.py
@@ -141,12 +141,12 @@ def sharer(step):
     step (16, 'Sharer Final step')
 
 @add_worker
-def shareeOne(step):
+def reshareeUser(step):
 
-    step (2, 'Sharee One creates workdir')
+    step (2, 'Re-Sharee User creates workdir')
     d = make_workdir()
 
-    step (5, 'Sharee One syncs and validate files do not exist')
+    step (5, 'Re-Sharee User syncs and validate files do not exist')
 
     run_ocsync(d,user_num=2)
     list_files(d)
@@ -163,7 +163,7 @@ def shareeOne(step):
     logger.info ('Checking that %s is not present in local directory for Sharee One', sharedFile)
     error_check(not os.path.exists(sharedFile), "File %s should not exist" %sharedFile)
 
-    step (9, 'Sharee one validates share file')
+    step (9, 'Re-Sharee User validates share file')
 
     run_ocsync(d,user_num=2)
     list_files(d)
@@ -172,7 +172,7 @@ def shareeOne(step):
     logger.info ('Checking that %s is present in local directory for Sharee One', sharedFile)
     error_check(os.path.exists(sharedFile), "File %s should exist" %sharedFile)
 
-    step (11, 'Sharee one validates file does not exist after unsharing')
+    step (11, 'Re-Sharee User validates file does not exist after unsharing')
 
     run_ocsync(d,user_num=2)
     list_files(d)
@@ -181,7 +181,7 @@ def shareeOne(step):
     logger.info ('Checking that %s is not present in sharee local directory', sharedFile)
     error_check(not os.path.exists(sharedFile), "File %s should not exist" %sharedFile)
 
-    step (13, 'Sharee One syncs and validates file does not exist')
+    step (13, 'Re-Sharee User syncs and validates file does not exist')
 
     run_ocsync(d,user_num=2)
     list_files(d)
@@ -190,15 +190,15 @@ def shareeOne(step):
     logger.info ('Checking that %s is not present in sharee local directory', sharedFile)
     error_check(not os.path.exists(sharedFile), "File %s should not exist" %sharedFile)
 
-    step (16, 'Sharee One final step')
+    step (16, 'Re-Sharee User final step')
 
 @add_worker
-def shareeTwo(step):
+def shareeGroup(step):
   
-    step (2, 'Sharee Two creates workdir')
+    step (2, 'Sharee Group creates workdir')
     d = make_workdir()
 
-    step (5, 'Sharee Two syncs and validate files do exist')
+    step (5, 'Sharee Group syncs and validate files do exist')
 
     run_ocsync(d,user_num=3)
     list_files(d)
@@ -215,20 +215,20 @@ def shareeTwo(step):
     logger.info ('Checking that %s is present in local directory for Sharee Two', sharedFile)
     error_check(os.path.exists(sharedFile), "File %s should exist" %sharedFile)
 
-    step (6, 'Sharee Two modifies TEST_FILE_MODIFIED_GROUP_SHARE.dat')
+    step (6, 'Sharee Group modifies TEST_FILE_MODIFIED_GROUP_SHARE.dat')
 
     modify_file(os.path.join(d,'TEST_FILE_MODIFIED_GROUP_SHARE.dat'),'1',count=10,bs=filesizeKB)
     run_ocsync(d,user_num=3)
     list_files(d)
 
-    step (8, 'Sharee Two shares file with Sharee One')
+    step (8, 'Sharee Group shares file with Sharee One')
 
     user2 = "%s%i"%(config.oc_account_name, 2)
     user3 = "%s%i"%(config.oc_account_name, 3)
     kwargs = {'perms': OCS_PERMISSION_ALL}
     share_file_with_user ('TEST_FILE_GROUP_RESHARE.dat', user3, user2, **kwargs)
 
-    step (11, 'Sharee two validates file does not exist after unsharing')
+    step (11, 'Sharee Group validates file does not exist after unsharing')
 
     run_ocsync(d,user_num=3)
     list_files(d)
@@ -236,7 +236,8 @@ def shareeTwo(step):
     sharedFile = os.path.join(d,'TEST_FILE_GROUP_RESHARE.dat')
     logger.info ('Checking that %s is not present in sharee local directory', sharedFile)
     error_check(not os.path.exists(sharedFile), "File %s should not exist" %sharedFile)
-    step (13, 'Sharee two validates file does not exist after deleting')
+
+    step (13, 'Sharee Group validates file does not exist after deleting')
 
     run_ocsync(d,user_num=3)
     list_files(d)
@@ -244,7 +245,8 @@ def shareeTwo(step):
     sharedFile = os.path.join(d,'TEST_FILE_MODIFIED_GROUP_SHARE.dat')
     logger.info ('Checking that %s is not present in sharee local directory', sharedFile)
     error_check(not os.path.exists(sharedFile), "File %s should not exist" %sharedFile)
-    step (15, 'Sharee two validates file does not exist after being removed from group')
+
+    step (15, 'Sharee Group validates file does not exist after being removed from group')
 
     run_ocsync(d,user_num=3)
     list_files(d)

--- a/lib/oc-tests/test_shareGroup.py
+++ b/lib/oc-tests/test_shareGroup.py
@@ -156,15 +156,15 @@ def shareeGroup(step):
 
     sharedFile = os.path.join(d,'TEST_FILE_GROUP_SHARE.dat')
     logger.info ('Checking that %s is present in local directory for Sharee Two', sharedFile)
-    error_check(os.path.exists(sharedFile), "File %s should exist" %sharedFile)
+    expect_exists(sharedFile)
 
     sharedFile = os.path.join(d,'TEST_FILE_GROUP_RESHARE.dat')
     logger.info ('Checking that %s is present in local directory for Sharee Two', sharedFile)
-    error_check(os.path.exists(sharedFile), "File %s should exist" %sharedFile)
+    expect_exists(sharedFile)
 
     sharedFile = os.path.join(d,'TEST_FILE_MODIFIED_GROUP_SHARE.dat')
     logger.info ('Checking that %s is present in local directory for Sharee Two', sharedFile)
-    error_check(os.path.exists(sharedFile), "File %s should exist" %sharedFile)
+    expect_exists(sharedFile)
 
     step (6, 'Sharee Group modifies TEST_FILE_MODIFIED_GROUP_SHARE.dat')
 
@@ -188,7 +188,7 @@ def shareeGroup(step):
 
     sharedFile = os.path.join(d,'TEST_FILE_GROUP_RESHARE.dat')
     logger.info ('Checking that %s is not present in sharee local directory', sharedFile)
-    error_check(not os.path.exists(sharedFile), "File %s should not exist" %sharedFile)
+    expect_does_not_exist(sharedFile)
 
     step (13, 'Sharee Group validates file does not exist after deleting')
 
@@ -197,7 +197,7 @@ def shareeGroup(step):
 
     sharedFile = os.path.join(d,'TEST_FILE_MODIFIED_GROUP_SHARE.dat')
     logger.info ('Checking that %s is not present in sharee local directory', sharedFile)
-    error_check(not os.path.exists(sharedFile), "File %s should not exist" %sharedFile)
+    expect_does_not_exist(sharedFile)
 
     step (15, 'Sharee Group validates file does not exist after being removed from group')
 
@@ -206,7 +206,7 @@ def shareeGroup(step):
 
     sharedFile = os.path.join(d,'TEST_FILE_GROUP_SHARE.dat')
     logger.info ('Checking that %s is not present in sharee local directory', sharedFile)
-    error_check(not os.path.exists(sharedFile), "File %s should not exist" %sharedFile)
+    expect_does_not_exist(sharedFile)
 
     step (16, 'Sharee Two final step')
 
@@ -223,15 +223,15 @@ def reshareeUser(step):
 
     sharedFile = os.path.join(d,'TEST_FILE_GROUP_SHARE.dat')
     logger.info ('Checking that %s is not present in local directory for Sharee One', sharedFile)
-    error_check(not os.path.exists(sharedFile), "File %s should not exist" %sharedFile)
+    expect_does_not_exist(sharedFile)
 
     sharedFile = os.path.join(d,'TEST_FILE_GROUP_RESHARE.dat')
     logger.info ('Checking that %s is not present in local directory for Sharee One', sharedFile)
-    error_check(not os.path.exists(sharedFile), "File %s should not exist" %sharedFile)
+    expect_does_not_exist(sharedFile)
 
     sharedFile = os.path.join(d,'TEST_FILE_MODIFIED_GROUP_SHARE.dat')
     logger.info ('Checking that %s is not present in local directory for Sharee One', sharedFile)
-    error_check(not os.path.exists(sharedFile), "File %s should not exist" %sharedFile)
+    expect_does_not_exist(sharedFile)
 
     step (9, 'Re-Sharee User validates share file')
 
@@ -240,7 +240,7 @@ def reshareeUser(step):
 
     sharedFile = os.path.join(d,'TEST_FILE_GROUP_RESHARE.dat')
     logger.info ('Checking that %s is present in local directory for Sharee One', sharedFile)
-    error_check(os.path.exists(sharedFile), "File %s should exist" %sharedFile)
+    expect_exists(sharedFile)
 
     step (11, 'Re-Sharee User validates file does not exist after unsharing')
 
@@ -249,7 +249,7 @@ def reshareeUser(step):
 
     sharedFile = os.path.join(d,'TEST_FILE_GROUP_RESHARE.dat')
     logger.info ('Checking that %s is not present in sharee local directory', sharedFile)
-    error_check(not os.path.exists(sharedFile), "File %s should not exist" %sharedFile)
+    expect_does_not_exist(sharedFile)
 
     step (13, 'Re-Sharee User syncs and validates file does not exist')
 
@@ -258,7 +258,7 @@ def reshareeUser(step):
 
     sharedFile = os.path.join(d,'TEST_FILE_GROUP_SHARE.dat')
     logger.info ('Checking that %s is not present in sharee local directory', sharedFile)
-    error_check(not os.path.exists(sharedFile), "File %s should not exist" %sharedFile)
+    expect_does_not_exist(sharedFile)
 
     step (16, 'Re-Sharee User final step')
 

--- a/lib/oc-tests/test_shareGroup.py
+++ b/lib/oc-tests/test_shareGroup.py
@@ -127,7 +127,9 @@ def sharer(step):
 
     step (7, 'Sharer validates modified file')
     run_ocsync(d,user_num=1)
-    expect_modified(os.path.join(d,'TEST_FILE_MODIFIED_GROUP_SHARE.dat'), shared['md5_sharer'])
+    list_files(d)
+    expect_modified(os.path.join(d,'TEST_FILE_MODIFIED_GROUP_SHARE.dat'), shared['md5_sharer'], comparedTo="original file from sharer")
+    expect_not_modified(os.path.join(d,'TEST_FILE_MODIFIED_GROUP_SHARE.dat'), shared['md5_shareeGroup'], comparedTo="file from Sharee Group")
 
     step (10, 'Sharer unshares a file')
     delete_share (user1, shared['TEST_FILE_GROUP_RESHARE'])
@@ -167,6 +169,8 @@ def shareeGroup(step):
     step (6, 'Sharee Group modifies TEST_FILE_MODIFIED_GROUP_SHARE.dat')
 
     modify_file(os.path.join(d,'TEST_FILE_MODIFIED_GROUP_SHARE.dat'),'1',count=10,bs=filesizeKB)
+    shared = reflection.getSharedObject()
+    shared['md5_shareeGroup'] = md5sum(os.path.join(d,'TEST_FILE_MODIFIED_GROUP_SHARE.dat'))
     run_ocsync(d,user_num=2)
     list_files(d)
 

--- a/lib/oc-tests/test_shareGroup.py
+++ b/lib/oc-tests/test_shareGroup.py
@@ -128,8 +128,8 @@ def sharer(step):
     step (7, 'Sharer validates modified file')
     run_ocsync(d,user_num=1)
     list_files(d)
-    expect_modified(os.path.join(d,'TEST_FILE_MODIFIED_GROUP_SHARE.dat'), shared['md5_sharer'], comparedTo="original file from sharer")
-    expect_not_modified(os.path.join(d,'TEST_FILE_MODIFIED_GROUP_SHARE.dat'), shared['md5_shareeGroup'], comparedTo="file from Sharee Group")
+    expect_modified(os.path.join(d,'TEST_FILE_MODIFIED_GROUP_SHARE.dat'), shared['md5_sharer'], comment=" compared to original file from sharer")
+    expect_not_modified(os.path.join(d,'TEST_FILE_MODIFIED_GROUP_SHARE.dat'), shared['md5_shareeGroup'], comment=" compared to file from Sharee Group")
 
     step (10, 'Sharer unshares a file')
     delete_share (user1, shared['TEST_FILE_GROUP_RESHARE'])

--- a/lib/oc-tests/test_shareGroup.py
+++ b/lib/oc-tests/test_shareGroup.py
@@ -1,11 +1,12 @@
 
 __doc__ = """
 
-Test basic file sharing between users in a group.  
+Test basic file sharing between users in a group.
 
 +-----------+-----------------+------------------+------------------+--------------+
-|  Step     |  Sharer         |  Sharee One      |  Sharee Two      |  Admin       |
-|  Number   |                 |  (not in group)  |  (in group)      |              |
+|  Step     |  Sharer (user1) |  Sharee Group    |  Re-Sharee User  |  Admin       |
+|  Number   |                 |  (in group)      |  (not in group)  |              |
+|           |                 |  (user2)         |  (user3)         |              |
 +===========+======================+==================+============================|
 |  2        | create work dir | create work dir  |  create work dir |              |
 +-----------+-----------------+------------------+------------------+--------------+
@@ -13,14 +14,14 @@ Test basic file sharing between users in a group.
 |           | files and dir   |                  |                  |              |
 +-----------+-----------------+------------------+------------------+--------------+
 |  4        | Shares files    |                  |                  |              |
-|           | with group      |                  |                  |              |
+|           | with group1     |                  |                  |              |
 +-----------+-----------------+------------------+------------------+--------------+
 |  5        |                 | Syncs and        | Syncs and        |              |
 |           |                 | validates files  | validates files  |              |
-|           |                 | do not exist     | exist            |              |
+|           |                 | exist            | do not exist     |              |
 +-----------+-----------------+------------------+------------------+--------------+
-|  6        |                 |                  | Modifies one     |              |
-|           |                 |                  | file, if allowed |              |
+|  6        |                 | Modifies one     |                  |              |
+|           |                 | file, if allowed |                  |              |
 +-----------+-----------------+------------------+------------------+--------------+
 |  7        | Validates       |                  |                  |              |
 |           | file modified   |                  |                  |              |
@@ -28,14 +29,14 @@ Test basic file sharing between users in a group.
 |           | based on        |                  |                  |              |
 |           | permissions     |                  |                  |              |
 +-----------+-----------------+------------------+------------------+--------------+
-|  8        |                 |                  |  Shares a file   |              |
-|           |                 |                  |  with sharee one |              |
-|           |                 |                  |  if permitted    |              |
+|  8        |                 | Shares a file    |                  |              |
+|           |                 | with user3       |                  |              |
+|           |                 | if permitted     |                  |              |
 +-----------+-----------------+------------------+------------------+--------------+
-|  9        |                 | Syncs and        |                  |              |
-|           |                 | validates file   |                  |              |
-|           |                 | is shared if     |                  |              |
-|           |                 | permitted        |                  |              |
+|  9        |                 |                  | Syncs and        |              |
+|           |                 |                  | validates file   |              |
+|           |                 |                  | is shared if     |              |
+|           |                 |                  | permitted        |              |
 +-----------+-----------------+------------------+------------------+--------------+
 |  10       | Sharer unshares |                  |                  |              |
 |           | a file          |                  |                  |              |
@@ -54,9 +55,9 @@ Test basic file sharing between users in a group.
 | 14        |                 |                  |                  | Removes user |
 |           |                 |                  |                  | from Group   |
 +-----------+-----------------+------------------+------------------+--------------+
-| 15        |                 |                  |  Syncs and       |              |
-|           |                 |                  |  verifies file   |              |
-|           |                 |                  |  not present     |              |
+| 15        |                 |  Syncs and       |                  |              |
+|           |                 |  verifies file   |                  |              |
+|           |                 |  not present     |                  |              |
 +-----------+-----------------+------------------+------------------+--------------+
 | 16        | Final step      | Final step       |  Final Step      | Final Step   |
 +-----------+-----------------+------------------+------------------+--------------+
@@ -88,9 +89,9 @@ def setup(step):
     reset_owncloud_group(num_groups=config.oc_number_test_groups)
     check_groups(config.oc_number_test_groups)
 
-    user3 = "%s%i"%(config.oc_account_name, 3)
+    user2 = "%s%i"%(config.oc_account_name, 2)
     group1 = "%s%i"%(config.oc_group_name, 1)
-    add_user_to_group(user3, group1)
+    add_user_to_group(user2, group1)
 
     reset_rundir()
 
@@ -141,66 +142,14 @@ def sharer(step):
     step (16, 'Sharer Final step')
 
 @add_worker
-def reshareeUser(step):
-
-    step (2, 'Re-Sharee User creates workdir')
-    d = make_workdir()
-
-    step (5, 'Re-Sharee User syncs and validate files do not exist')
-
-    run_ocsync(d,user_num=2)
-    list_files(d)
-
-    sharedFile = os.path.join(d,'TEST_FILE_GROUP_SHARE.dat')
-    logger.info ('Checking that %s is not present in local directory for Sharee One', sharedFile)
-    error_check(not os.path.exists(sharedFile), "File %s should not exist" %sharedFile)
-
-    sharedFile = os.path.join(d,'TEST_FILE_GROUP_RESHARE.dat')
-    logger.info ('Checking that %s is not present in local directory for Sharee One', sharedFile)
-    error_check(not os.path.exists(sharedFile), "File %s should not exist" %sharedFile)
-
-    sharedFile = os.path.join(d,'TEST_FILE_MODIFIED_GROUP_SHARE.dat')
-    logger.info ('Checking that %s is not present in local directory for Sharee One', sharedFile)
-    error_check(not os.path.exists(sharedFile), "File %s should not exist" %sharedFile)
-
-    step (9, 'Re-Sharee User validates share file')
-
-    run_ocsync(d,user_num=2)
-    list_files(d)
-
-    sharedFile = os.path.join(d,'TEST_FILE_GROUP_RESHARE.dat')
-    logger.info ('Checking that %s is present in local directory for Sharee One', sharedFile)
-    error_check(os.path.exists(sharedFile), "File %s should exist" %sharedFile)
-
-    step (11, 'Re-Sharee User validates file does not exist after unsharing')
-
-    run_ocsync(d,user_num=2)
-    list_files(d)
-
-    sharedFile = os.path.join(d,'TEST_FILE_GROUP_RESHARE.dat')
-    logger.info ('Checking that %s is not present in sharee local directory', sharedFile)
-    error_check(not os.path.exists(sharedFile), "File %s should not exist" %sharedFile)
-
-    step (13, 'Re-Sharee User syncs and validates file does not exist')
-
-    run_ocsync(d,user_num=2)
-    list_files(d)
-
-    sharedFile = os.path.join(d,'TEST_FILE_GROUP_SHARE.dat')
-    logger.info ('Checking that %s is not present in sharee local directory', sharedFile)
-    error_check(not os.path.exists(sharedFile), "File %s should not exist" %sharedFile)
-
-    step (16, 'Re-Sharee User final step')
-
-@add_worker
 def shareeGroup(step):
-  
+
     step (2, 'Sharee Group creates workdir')
     d = make_workdir()
 
     step (5, 'Sharee Group syncs and validate files do exist')
 
-    run_ocsync(d,user_num=3)
+    run_ocsync(d,user_num=2)
     list_files(d)
 
     sharedFile = os.path.join(d,'TEST_FILE_GROUP_SHARE.dat')
@@ -218,7 +167,7 @@ def shareeGroup(step):
     step (6, 'Sharee Group modifies TEST_FILE_MODIFIED_GROUP_SHARE.dat')
 
     modify_file(os.path.join(d,'TEST_FILE_MODIFIED_GROUP_SHARE.dat'),'1',count=10,bs=filesizeKB)
-    run_ocsync(d,user_num=3)
+    run_ocsync(d,user_num=2)
     list_files(d)
 
     step (8, 'Sharee Group shares file with Sharee One')
@@ -226,11 +175,11 @@ def shareeGroup(step):
     user2 = "%s%i"%(config.oc_account_name, 2)
     user3 = "%s%i"%(config.oc_account_name, 3)
     kwargs = {'perms': OCS_PERMISSION_ALL}
-    share_file_with_user ('TEST_FILE_GROUP_RESHARE.dat', user3, user2, **kwargs)
+    share_file_with_user ('TEST_FILE_GROUP_RESHARE.dat', user2, user3, **kwargs)
 
     step (11, 'Sharee Group validates file does not exist after unsharing')
 
-    run_ocsync(d,user_num=3)
+    run_ocsync(d,user_num=2)
     list_files(d)
 
     sharedFile = os.path.join(d,'TEST_FILE_GROUP_RESHARE.dat')
@@ -239,7 +188,7 @@ def shareeGroup(step):
 
     step (13, 'Sharee Group validates file does not exist after deleting')
 
-    run_ocsync(d,user_num=3)
+    run_ocsync(d,user_num=2)
     list_files(d)
 
     sharedFile = os.path.join(d,'TEST_FILE_MODIFIED_GROUP_SHARE.dat')
@@ -248,7 +197,7 @@ def shareeGroup(step):
 
     step (15, 'Sharee Group validates file does not exist after being removed from group')
 
-    run_ocsync(d,user_num=3)
+    run_ocsync(d,user_num=2)
     list_files(d)
 
     sharedFile = os.path.join(d,'TEST_FILE_GROUP_SHARE.dat')
@@ -258,14 +207,66 @@ def shareeGroup(step):
     step (16, 'Sharee Two final step')
 
 @add_worker
+def reshareeUser(step):
+
+    step (2, 'Re-Sharee User creates workdir')
+    d = make_workdir()
+
+    step (5, 'Re-Sharee User syncs and validate files do not exist')
+
+    run_ocsync(d,user_num=3)
+    list_files(d)
+
+    sharedFile = os.path.join(d,'TEST_FILE_GROUP_SHARE.dat')
+    logger.info ('Checking that %s is not present in local directory for Sharee One', sharedFile)
+    error_check(not os.path.exists(sharedFile), "File %s should not exist" %sharedFile)
+
+    sharedFile = os.path.join(d,'TEST_FILE_GROUP_RESHARE.dat')
+    logger.info ('Checking that %s is not present in local directory for Sharee One', sharedFile)
+    error_check(not os.path.exists(sharedFile), "File %s should not exist" %sharedFile)
+
+    sharedFile = os.path.join(d,'TEST_FILE_MODIFIED_GROUP_SHARE.dat')
+    logger.info ('Checking that %s is not present in local directory for Sharee One', sharedFile)
+    error_check(not os.path.exists(sharedFile), "File %s should not exist" %sharedFile)
+
+    step (9, 'Re-Sharee User validates share file')
+
+    run_ocsync(d,user_num=3)
+    list_files(d)
+
+    sharedFile = os.path.join(d,'TEST_FILE_GROUP_RESHARE.dat')
+    logger.info ('Checking that %s is present in local directory for Sharee One', sharedFile)
+    error_check(os.path.exists(sharedFile), "File %s should exist" %sharedFile)
+
+    step (11, 'Re-Sharee User validates file does not exist after unsharing')
+
+    run_ocsync(d,user_num=3)
+    list_files(d)
+
+    sharedFile = os.path.join(d,'TEST_FILE_GROUP_RESHARE.dat')
+    logger.info ('Checking that %s is not present in sharee local directory', sharedFile)
+    error_check(not os.path.exists(sharedFile), "File %s should not exist" %sharedFile)
+
+    step (13, 'Re-Sharee User syncs and validates file does not exist')
+
+    run_ocsync(d,user_num=3)
+    list_files(d)
+
+    sharedFile = os.path.join(d,'TEST_FILE_GROUP_SHARE.dat')
+    logger.info ('Checking that %s is not present in sharee local directory', sharedFile)
+    error_check(not os.path.exists(sharedFile), "File %s should not exist" %sharedFile)
+
+    step (16, 'Re-Sharee User final step')
+
+@add_worker
 def admin(step):
 
 
     step (14, 'Admin user removes user from group')
 
-    user3 = "%s%i"%(config.oc_account_name, 3)
+    user2 = "%s%i"%(config.oc_account_name, 2)
     group1 = "%s%i"%(config.oc_group_name, 1)
-    remove_user_from_group(user3, group1)
+    remove_user_from_group(user2, group1)
 
     step (16, 'Admin final step')
 

--- a/python/smashbox/utilities/__init__.py
+++ b/python/smashbox/utilities/__init__.py
@@ -668,20 +668,24 @@ def check_groups(num_groups=None):
             fatal_check(result, 'Group %s not found' % group_name)
 
 
-def expect_modified(fn, md5):
+def expect_modified(fn, md5, comparedTo=''):
     """ Compares that the checksum of two files is different
     """
     actual_md5 = md5sum(fn)
+    if comparedTo:
+        comparedTo = "%s%s" % (' compared to ', comparedTo)
     error_check(actual_md5 != md5,
-                "md5 of modified file %s did not change: expected %s, got %s" % (fn, md5, actual_md5))
+                "md5 of modified file %s did not change%s: expected %s, got %s" % (fn, comparedTo, md5, actual_md5))
 
 
-def expect_not_modified(fn, md5):
+def expect_not_modified(fn, md5, comparedTo=''):
     """ Compares that the checksum of two files is the same
     """
     actual_md5 = md5sum(fn)
+    if comparedTo:
+        comparedTo = "%s%s" % (' compared to ', comparedTo)
     error_check(actual_md5 == md5,
-                "md5 of modified file %s changed and should not have: expected %s, got %s" % (fn, md5, actual_md5))
+                "md5 of modified file %s changed%s and should not have: expected %s, got %s" % (fn, comparedTo, md5, actual_md5))
 
 
 def expect_exists(fn):

--- a/python/smashbox/utilities/__init__.py
+++ b/python/smashbox/utilities/__init__.py
@@ -668,24 +668,20 @@ def check_groups(num_groups=None):
             fatal_check(result, 'Group %s not found' % group_name)
 
 
-def expect_modified(fn, md5, comparedTo=''):
+def expect_modified(fn, md5, comment=''):
     """ Compares that the checksum of two files is different
     """
     actual_md5 = md5sum(fn)
-    if comparedTo:
-        comparedTo = "%s%s" % (' compared to ', comparedTo)
     error_check(actual_md5 != md5,
-                "md5 of modified file %s did not change%s: expected %s, got %s" % (fn, comparedTo, md5, actual_md5))
+                "md5 of modified file %s did not change%s: expected %s" % (fn, comment, md5))
 
 
-def expect_not_modified(fn, md5, comparedTo=''):
+def expect_not_modified(fn, md5, comment=''):
     """ Compares that the checksum of two files is the same
     """
     actual_md5 = md5sum(fn)
-    if comparedTo:
-        comparedTo = "%s%s" % (' compared to ', comparedTo)
     error_check(actual_md5 == md5,
-                "md5 of modified file %s changed%s and should not have: expected %s, got %s" % (fn, comparedTo, md5, actual_md5))
+                "md5 of modified file %s changed%s and should not have: expected %s, got %s" % (fn, comment, md5, actual_md5))
 
 
 def expect_exists(fn):


### PR DESCRIPTION
- Step1 fix the names to be more descriptive
- Step2 fix the order (so we dont share user1 > user3 > user2, but 1 > 2 > 3)
- Step3 compare the md5 to the one of the group sharee, to make sure the file is uploaded correctly, (which it is not in owncloud's current master, see https://github.com/owncloud/core/issues/17188 + https://github.com/owncloud/core/pull/17191 )
- Step4 use methods instead of doing the compare manually

For easier review have a look at the individual commits, the second commit is still odd, but I just switched the two `def` sections and replaced user2 with user3 and the otherway around.

@moscicki 
