### PR TITLE
Fix server scrape log

### DIFF
--- a/etc/smashbox.conf.template
+++ b/etc/smashbox.conf.template
@@ -129,3 +129,8 @@ scp_port = 22
 
 # user that can r+w the owncloud.log file (needs to be configured for passwordless login)
 oc_server_log_user = "www-data"
+
+#
+# Reset the server log file and verify that no exceptions and other known errors have been logged
+#
+oc_check_server_log = True

--- a/etc/smashbox.conf.template
+++ b/etc/smashbox.conf.template
@@ -124,6 +124,8 @@ del os
 # 
 pycurl_verbose = None
 
-#
 # scp port to be used in scp commands, used primarily when copying over the server log file
-scp_port=22
+scp_port = 22
+
+# user that can r+w the owncloud.log file (needs to be configured for passwordless login)
+oc_server_log_user = "www-data"

--- a/lib/oc-tests/test_reshareDir.py
+++ b/lib/oc-tests/test_reshareDir.py
@@ -123,7 +123,7 @@ def shareeTwo(step):
     dirName = "%s/%s"%(procName, 'localShareDir')
     localDir = make_workdir(dirName)
 
-    step (13, 'Sharee two validates share file')
+    step (7, 'Sharee two validates share file')
 
     run_ocsync(d,user_num=3)
     list_files(d)

--- a/python/smashbox/utilities/__init__.py
+++ b/python/smashbox/utilities/__init__.py
@@ -571,7 +571,8 @@ def scrape_log_file(d):
         except AttributeError:  # allow this option not to be defined at all
             log_user = 'root'
         cmd = 'scp -P %d %s@%s:%s/owncloud.log %s/.' % (config.scp_port, log_user, config.oc_server, config.oc_server_datadirectory, d)
-    runcmd(cmd)
+    rtn_code,stdout,stderr = runcmd(cmd)
+    error_check(rtn_code > 0, 'Could not copy the log file from the server, command returned %s' % rtn_code)
 
     # search logfile for string (1 == not found; 0 == found):
     cmd = "grep -i \"integrity constraint violation\" %s/owncloud.log" % d

--- a/python/smashbox/utilities/__init__.py
+++ b/python/smashbox/utilities/__init__.py
@@ -566,7 +566,11 @@ def scrape_log_file(d):
     if config.oc_server == '127.0.0.1' or config.oc_server == 'localhost':
         cmd = 'cp %s/owncloud.log %s/.' % (config.oc_server_datadirectory, d)
     else:
-        cmd = 'scp -P %d root@%s:%s/owncloud.log %s/.' % (config.scp_port, config.oc_server, config.oc_server_datadirectory, d)
+        try:
+            log_user = config.oc_server_log_user
+        except AttributeError:  # allow this option not to be defined at all
+            log_user = 'root'
+        cmd = 'scp -P %d %s@%s:%s/owncloud.log %s/.' % (config.scp_port, log_user, config.oc_server, config.oc_server_datadirectory, d)
     runcmd(cmd)
 
     # search logfile for string (1 == not found; 0 == found):

--- a/python/smashbox/utilities/__init__.py
+++ b/python/smashbox/utilities/__init__.py
@@ -563,13 +563,13 @@ def scrape_log_file(d):
     except AttributeError: # allow this option not to be defined at all
         return
 
-    cmd = 'scp -P %d root@%s:%s/owncloud.log %s/.' % (config.scp_port, config.oc_server, config.oc_server_datadirectory, d)
-    rtn_code,stdout,stderr = runcmd(cmd)
-
-    logger.info('copy command returned %s', rtn_code)
+    if config.oc_server == '127.0.0.1' or config.oc_server == 'localhost':
+        cmd = 'cp %s/owncloud.log %s/.' % (config.oc_server_datadirectory, d)
+    else:
+        cmd = 'scp -P %d root@%s:%s/owncloud.log %s/.' % (config.scp_port, config.oc_server, config.oc_server_datadirectory, d)
+    runcmd(cmd)
 
     # search logfile for string (1 == not found; 0 == found):
-
     cmd = "grep -i \"integrity constraint violation\" %s/owncloud.log" % d
     rtn_code,stdout,stderr = runcmd(cmd, ignore_exitcode=True, log_warning=False)
     error_check(rtn_code > 0, "\"Integrity Constraint Violation\" message found in server log file")


### PR DESCRIPTION
- Fix copying the log file on localhost (scp outputs warnings with "hacking attempt" style)
- Allow specifying a user that can touch the log file on the remote
- Add a config to allow disabling the check log

@moscicki 
