### PR TITLE
File removal replay has no fileId header.

### DIFF
--- a/protocol/protocol.md
+++ b/protocol/protocol.md
@@ -464,7 +464,7 @@ Request Custom Header: None
 
 Response Custom Header:
 
-`OC-FileId`: The fileId of the new file (directory).
+None.
 
 Specific error code handling:
 


### PR DESCRIPTION
As discussed in the other PR
