### PR TITLE
Check client existance and provisioning app in setup_test()

### DIFF
--- a/python/smashbox/utilities/__init__.py
+++ b/python/smashbox/utilities/__init__.py
@@ -26,6 +26,18 @@ def setup_test():
     If exception is raised then the testcase execution is aborted and smashbox terminates with non-zero exit code,
 
     """
+    cmd = config.oc_sync_cmd
+    if cmd[0 - len(' --trust'):] == ' --trust':
+        cmd = cmd[:0 - len(' --trust')]
+    cmd += ' --version'
+    returncode, stdout, stderr = runcmd(cmd, ignore_exitcode=True)  # exitcode of ocsync is not reliable
+
+    if returncode == 127:
+        error_check(False, 'Could not find the client in "%s"' % config.oc_sync_cmd)
+        exit(1)
+
+    logger.info('Client version: "%s"', stdout)
+
     reset_owncloud_account(num_test_users=config.oc_number_test_users)
     reset_rundir()
     reset_server_log_file()

--- a/python/smashbox/utilities/__init__.py
+++ b/python/smashbox/utilities/__init__.py
@@ -1,3 +1,4 @@
+from owncloud import HTTPResponseError, OCSResponseError
 from smashbox.script import config
 
 import os.path
@@ -37,6 +38,20 @@ def setup_test():
         exit(1)
 
     logger.info('Client version: "%s"', stdout)
+
+    oc_api = get_oc_api()
+
+    try:
+        oc_api.login(config.oc_admin_user, config.oc_admin_password)
+    except HTTPResponseError:
+        error_check(False, 'Could not login with admin account "%s"' % config.oc_admin_user)
+        exit(1)
+
+    try:
+        oc_api.get_apps()
+    except OCSResponseError:
+        error_check(False, 'Provisioning app is not enabled')
+        exit(1)
 
     reset_owncloud_account(num_test_users=config.oc_number_test_users)
     reset_rundir()


### PR DESCRIPTION
1. Check whether the sync client command exists (!= 127) https://github.com/owncloud/smashbox/issues/99
2. Log client version as info()
3. Check if the admin login works
4. Check if the provisioning app is enabled https://github.com/owncloud/smashbox/issues/126

Those checks are needed (tests can't work without them, no user creation etc.) so failing and exit(1)

@moscicki 

Fix https://github.com/owncloud/smashbox/issues/126
