### PR TITLE
Sharing behaviour change in 9.0

### DIFF
--- a/lib/oc-tests/test_shareDir.py
+++ b/lib/oc-tests/test_shareDir.py
@@ -63,9 +63,12 @@ Test basic directory and file sharing between users.
 |           |                 | validates        |                  |              |
 |           |                 | directory gone   |                  |              |
 +-----------+-----------------+------------------+------------------+--------------+
-|  18       |                 |                  |  Syncs and       |              |
-|           |                 |                  |  validates       |              |
-|           |                 |                  |  directory gone  |              |
+|  18       |                 |                  | Syncs and        |              |
+|           |                 |                  | validates        |              |
+|           |                 |                  | directory is     |              |
+|           |                 |                  | gone (<9.0) or   |              |
+|           |                 |                  | still there      |              |
+|           |                 |                  | (9.0+)           |              |
 +-----------+-----------------+------------------+------------------+--------------+
 |  19       | Final step      | Final step       |  Final Step      |              |
 +-----------+-----------------+------------------+------------------+--------------+
@@ -248,7 +251,10 @@ def shareeTwo(step):
     logger.info ('Checking that shared dir does contain the shared file %s for Sharee Two', sharedDirFile)
     expect_exists(sharedDirFile)
 
-    step (18, 'Sharee two syncs and validates directory does not exist')
+    if compare_oc_version('9.0', '<'):
+        step(18, 'Sharee two syncs and validates directory does not exist')
+    else:
+        step(18, 'Sharee two syncs and validates directory does still exist')
 
     run_ocsync(d,user_num=3)
     list_files(d)
@@ -258,7 +264,11 @@ def shareeTwo(step):
     expect_exists(localDir)
 
     sharedDir = os.path.join(d, 'localShareDir (2)')
-    logger.info ('Checking that %s is not present in sharee local directory', sharedDir)
-    expect_does_not_exist(sharedDir)
+    if compare_oc_version('9.0', '<'):
+        logger.info('Checking that %s is not present in sharee local directory', sharedDir)
+        expect_does_not_exist(sharedDir)
+    else:
+        logger.info('Checking that %s is still present in sharee local directory', sharedDir)
+        expect_exists(sharedDir)
 
     step (19, 'Sharee Two final step')

--- a/lib/oc-tests/test_shareGroup.py
+++ b/lib/oc-tests/test_shareGroup.py
@@ -44,6 +44,8 @@ Test basic file sharing between users in a group.
 |  11       |                 | Syncs and        | Syncs and        |              |
 |           |                 | validates file   | validates file   |              |
 |           |                 | not present      | not present      |              |
+|           |                 |                  | (<9.0) or is     |              |
+|           |                 |                  | present (9.0+)   |              |
 +-----------+-----------------+------------------+------------------+--------------+
 |  12       | Sharer deletes  |                  |                  |              |
 |           | a file          |                  |                  |              |
@@ -242,14 +244,21 @@ def reshareeUser(step):
     logger.info ('Checking that %s is present in local directory for Sharee One', sharedFile)
     expect_exists(sharedFile)
 
-    step (11, 'Re-Sharee User validates file does not exist after unsharing')
+    if compare_oc_version('9.0', '<'):
+        step(11, 'Re-Sharee User validates file does not exist after unsharing')
+    else:
+        step(11, 'Re-Sharee User validates file does still exist after unsharing')
 
     run_ocsync(d,user_num=3)
     list_files(d)
 
     sharedFile = os.path.join(d,'TEST_FILE_GROUP_RESHARE.dat')
-    logger.info ('Checking that %s is not present in sharee local directory', sharedFile)
-    expect_does_not_exist(sharedFile)
+    if compare_oc_version('9.0', '<'):
+        logger.info('Checking that %s is not present in sharee local file', sharedFile)
+        expect_does_not_exist(sharedFile)
+    else:
+        logger.info('Checking that %s is still present in sharee local file', sharedFile)
+        expect_exists(sharedFile)
 
     step (13, 'Re-Sharee User syncs and validates file does not exist')
 

--- a/python/smashbox/utilities/__init__.py
+++ b/python/smashbox/utilities/__init__.py
@@ -6,6 +6,7 @@ import subprocess
 import time
 
 # Utilities to be used in the test-cases.
+from smashbox.utilities.version import version_compare
 
 
 def compare_oc_version(compare_to, operator):
@@ -22,7 +23,7 @@ def compare_oc_version(compare_to, operator):
     import json
     version = (json.loads(std_out))['version']
 
-    return compare_version(compare_to, operator, version)
+    return version_compare(version, operator, compare_to)
 
 
 def compare_client_version(compare_to, operator):
@@ -42,35 +43,7 @@ def compare_client_version(compare_to, operator):
     if version[-4:-1] == 'git':
         version = version[:-4]
 
-    return compare_version(compare_to, operator, version)
-
-
-def compare_version(compare_to, operator, version):
-    """
-
-    :param compare_to: E.g. '9.0'
-    :param operator: One of '<', '=', '>', '<=', '>='
-    :param version: E.g. '9.0'
-    :return:
-    """
-
-    if operator == '<':
-        return versiontuple(version) < versiontuple(compare_to)
-    if operator == '>':
-        return versiontuple(version) > versiontuple(compare_to)
-    if operator == '<=':
-        return versiontuple(version) <= versiontuple(compare_to)
-    if operator == '>=':
-        return versiontuple(version) >= versiontuple(compare_to)
-    if operator == '=':
-        compare_tuple = versiontuple(compare_to)
-        return versiontuple(version)[0:len(compare_tuple)] == compare_tuple
-
-    raise ValueError('Invalid operator')
-
-
-def versiontuple(v):
-    return tuple(map(int, (v.split("."))))
+    return version_compare(version, operator, compare_to)
 
 
 def OWNCLOUD_CHUNK_SIZE(factor=1):

--- a/python/smashbox/utilities/__init__.py
+++ b/python/smashbox/utilities/__init__.py
@@ -675,8 +675,8 @@ def share_file_with_user(filename, sharer, sharee, **kwargs):
         logger.info('share id for file share is %s', str(share_info.share_id))
         return share_info.share_id
     except ResponseError as err:
-        logger.info('Share failed with %s', str(err))
-        if "not allowed to share" in str(err.get_resource_body()):
+        logger.info('Share failed with %s - %s', str(err), str(err.get_resource_body()))
+        if err.status_code == 403 or err.status_code == 404:
             return -1
         else:
             return -2

--- a/python/smashbox/utilities/__init__.py
+++ b/python/smashbox/utilities/__init__.py
@@ -7,6 +7,40 @@ import time
 
 # Utilities to be used in the test-cases.
 
+
+def compare_oc_version(compare_to, operator):
+    """
+
+    :param compare_to: E.g. '9.0'
+    :param operator: One of '<', '=', '>', '<=', '>='
+    :return:
+    """
+    oc_api = get_oc_api()
+    url = oc_api.url + 'status.php'
+    rtn_code, std_out, std_err = runcmd('curl %s' % url, log_warning=False)
+
+    import json
+    version = (json.loads(std_out))['version']
+
+    if operator == '<':
+        return versiontuple(version) < versiontuple(compare_to)
+    if operator == '>':
+        return versiontuple(version) > versiontuple(compare_to)
+    if operator == '<=':
+        return versiontuple(version) <= versiontuple(compare_to)
+    if operator == '>=':
+        return versiontuple(version) >= versiontuple(compare_to)
+    if operator == '=':
+        compare_tuple = versiontuple(compare_to)
+        return versiontuple(version)[0:len(compare_tuple)] == compare_tuple
+
+    raise ValueError('Invalid operator')
+
+
+def versiontuple(v):
+    return tuple(map(int, (v.split("."))))
+
+
 def OWNCLOUD_CHUNK_SIZE(factor=1):
     """Calculate file size as a fraction of owncloud client's default chunk size.
     """

--- a/python/smashbox/utilities/__init__.py
+++ b/python/smashbox/utilities/__init__.py
@@ -22,6 +22,38 @@ def compare_oc_version(compare_to, operator):
     import json
     version = (json.loads(std_out))['version']
 
+    return compare_version(compare_to, operator, version)
+
+
+def compare_client_version(compare_to, operator):
+    """
+
+    :param compare_to: E.g. '2.1'
+    :param operator: One of '<', '=', '>', '<=', '>='
+    :return:
+    """
+
+    cmd = config.oc_sync_cmd
+    cmd = cmd[:cmd.find(' --')]
+    cmd += ' --version'
+    rtn_code, std_out, std_err = runcmd(cmd)
+
+    version = std_out[std_out.find(' version ') + 9:]
+    if version[-4:-1] == 'git':
+        version = version[:-4]
+
+    return compare_version(compare_to, operator, version)
+
+
+def compare_version(compare_to, operator, version):
+    """
+
+    :param compare_to: E.g. '9.0'
+    :param operator: One of '<', '=', '>', '<=', '>='
+    :param version: E.g. '9.0'
+    :return:
+    """
+
     if operator == '<':
         return versiontuple(version) < versiontuple(compare_to)
     if operator == '>':

--- a/python/smashbox/utilities/version.py
+++ b/python/smashbox/utilities/version.py
@@ -1,0 +1,151 @@
+import operator
+
+
+def version_compare(v1, operator, v2):
+    """
+    The function first replaces _, - and + with a dot . in the version strings and also inserts dots . before and
+    after any non number so that for example '4.3.2RC1' becomes '4.3.2.RC.1'. Then it compares the parts starting
+    from left to right. If a part contains special version strings these are handled in the following order:
+        any string not found in this list < dev < alpha = a < beta = b < RC = rc < #
+    This way not only versions with different levels like '4.1' and '4.1.2' can be compared but also any version
+    containing development state.
+
+    :param v1: Version to compare
+    :param operator: Can be one of <, <=, =, !=, >=, >
+    :param v2: Version to compare against
+    :return: Boolean
+    """
+    return __version_compare_tuple(__normalize_version(v1), operator, __normalize_version(v2))
+
+
+def __version_compare_tuple(t1, compare, t2):
+
+    # Make both versions the same length
+    if len(t1) < len(t2):
+        for i in range(len(t1), len(t2)):
+            t1.append(0)
+    elif len(t2) < len(t1):
+        for i in range(len(t2), len(t1)):
+            t2.append(0)
+
+    if compare == '<':
+        return operator.lt(t1, t2)
+    elif compare == '<=':
+        return operator.le(t1, t2)
+    elif compare == '=' or compare == '==':
+        return operator.eq(t1, t2)
+    elif compare == '!=':
+        return operator.ne(t1, t2)
+    elif compare == '>=':
+        return operator.ge(t1, t2)
+    elif compare == '>':
+        return operator.gt(t1, t2)
+    else:
+        raise ValueError('Invalid operator')
+
+
+def __normalize_version(version):
+    v = version.lower()
+    v = v.replace('-', '.')
+    v = v.replace('_', '.')
+    v = v.replace('+', '.')
+
+    fixed_version = ''
+    last_was_digit = True
+    for char in v:
+        if (char.isdigit() or char == '.') and not last_was_digit:
+            fixed_version += '.'
+            last_was_digit = True
+        elif not (char.isdigit() or char == '.') and last_was_digit:
+            fixed_version += '.'
+            last_was_digit = False
+        fixed_version += char
+
+    v = fixed_version
+
+    while '..' in v:
+        v = v.replace('..', '.')
+
+    if v[:1] == '.':
+        v = v[1:]
+    if v[-1:] == '.':
+        v = v[:-1]
+
+    return map(__prepare_tuple, v.split("."))
+
+
+def __prepare_tuple(item):
+    """
+    Replaces strings with integers, so we can compare them correctly:
+    any string not found in this list < dev < alpha = a < beta = b < RC = rc < #
+
+    :param item:
+    :return:
+    """
+    if item == 'dev':
+        return -4
+    if item == 'a' or item == 'alpha':
+        return -3
+    if item == 'b' or item == 'beta':
+        return -2
+    if item == 'rc':
+        return -1
+    if item.isdigit():
+        return int(item)
+#    if item == 'pl' or item == 'p':
+#        return sys.maxsize
+
+    # Any other string that is no number string
+    return -5
+
+
+if __name__ == "__main__":
+
+    def assert_version_compare(v1, operator, v2, result):
+        if version_compare(v1, operator, v2) == result:
+            print('[PASS] Comparing %s %s %s' % (v1, operator, v2))
+        else:
+            print('[ERROR] Comparing %s %s %s' % (v1, operator, v2))
+
+    assert_version_compare('2.1.0alpha1', '<', '2.1.0beta1', True)
+    assert_version_compare('2.1.0alpha1', '<=', '2.1.0beta1', True)
+    assert_version_compare('2.1.0alpha1', '=', '2.1.0beta1', False)
+    assert_version_compare('2.1.0alpha1', '>=', '2.1.0beta1', False)
+    assert_version_compare('2.1.0alpha1', '>', '2.1.0beta1', False)
+
+    assert_version_compare('2.1.0beta1', '<', '2.1.0rc1', True)
+    assert_version_compare('2.1.0beta1', '<=', '2.1.0rc1', True)
+    assert_version_compare('2.1.0beta1', '=', '2.1.0rc1', False)
+    assert_version_compare('2.1.0beta1', '>=', '2.1.0rc1', False)
+    assert_version_compare('2.1.0beta1', '>', '2.1.0rc1', False)
+
+    assert_version_compare('2.1.0rc1', '<', '2.1.0', True)
+    assert_version_compare('2.1.0rc1', '<=', '2.1.0', True)
+    assert_version_compare('2.1.0rc1', '=', '2.1.0', False)
+    assert_version_compare('2.1.0rc1', '>=', '2.1.0', False)
+    assert_version_compare('2.1.0rc1', '>', '2.1.0', False)
+
+    assert_version_compare('2.1.0', '<', '2.1.0', False)
+    assert_version_compare('2.1.0', '<=', '2.1.0', True)
+    assert_version_compare('2.1.0', '=', '2.1.0', True)
+    assert_version_compare('2.1.0', '>=', '2.1.0', True)
+    assert_version_compare('2.1.0', '>', '2.1.0', False)
+
+    assert_version_compare('2.1.0', '<', '2.1', False)
+    assert_version_compare('2.1.0', '<=', '2.1', True)
+    assert_version_compare('2.1.0', '=', '2.1', True)
+    assert_version_compare('2.1.0', '>=', '2.1', True)
+    assert_version_compare('2.1.0', '>', '2.1', False)
+
+    assert_version_compare('2.1.1', '<', '2.1.0', False)
+    assert_version_compare('2.1.1', '<=', '2.1.0', False)
+    assert_version_compare('2.1.1', '=', '2.1.0', False)
+    assert_version_compare('2.1.1', '>=', '2.1.0', True)
+    assert_version_compare('2.1.1', '>', '2.1.0', True)
+
+    assert_version_compare('2.1.1', '<', '2.1', False)
+    assert_version_compare('2.1.1', '<=', '2.1', False)
+    assert_version_compare('2.1.1', '=', '2.1', False)
+    assert_version_compare('2.1.1', '>=', '2.1', True)
+    assert_version_compare('2.1.1', '>', '2.1', True)
+


### PR DESCRIPTION
In 9.0 ownCloud changes how reshares are handled.
1. User A shares file to User B
2. User B shares the same file to User C
3. User A removes User B from the share list
### pre 9.0

User C can not see the file anymore
### 9.0+

User C still has the file shared

Therefor the tests need to be adjusted to reflect that behaviour:
- I added a method to allow comparing the owncloud version, so we can make sure that works as intended for each version and we don't need to duplicate all the tests with pre and post 9.0 logic.
- I modified the check for "sharing failed" to rely on the status code (403) rather then the message, because that was changed as well:
  - Previous: `You are not allowed to share /TEST_FILE_USER_RESHARE.dat`
  - New: `Path is not shareable`

@moscicki 

ref https://github.com/owncloud/smashbox/pull/140
