### PR TITLE
Fixed logic in relative path check for oc_sync_cmd

### DIFF
--- a/bin/smash
+++ b/bin/smash
@@ -132,7 +132,7 @@ def main():
    oc_sync_cmd_exe_dirname = os.path.dirname(oc_sync_cmd_exe) # take first word of the string (other words may be arguments)
 
    if oc_sync_cmd_exe_dirname:
-      if not oc_sync_cmd_exe_dirname.startswith('./') or not oc_sync_cmd_exe_dirname.startswith('/'):
+      if not oc_sync_cmd_exe_dirname.startswith('./') and not oc_sync_cmd_exe_dirname.startswith('/'):
          logger.critical("config error: relative paths for oc_sync_cmd must start with ./ : %s",config.oc_sync_cmd)
          sys.exit(1)
       config.oc_sync_cmd = os.path.normpath(os.path.join(top_smash,config.oc_sync_cmd))


### PR DESCRIPTION
Absolute path starts with / and for old conditional check we will have
`not FALSE or not TRUE => TRUE`
and critical error for right path to oc_sync_cmd_exe.