### PR TITLE
Update test_basicSync.py

### DIFF
--- a/lib/test_basicSync.py
+++ b/lib/test_basicSync.py
@@ -64,7 +64,7 @@ testsets = []
 # create cartesian product of all test configurations
 for s in [1, 5000, 15000, 50000]:
   for t in [True, False]:
-      for p in [ "", "abc", "abc/abc", "abc/def/ghi" ]:
+      for p in [ "", "abc", "abc\\abc", "abc\def\ghi" ]:
           testsets.append( { 'basicSync_filesizeKB':s,
                              'basicSync_rmLocalStateDB':t,
                              'basicSync_subdirPath':p } )


### PR DESCRIPTION
Changed basicSYnc '/' with '\\' and '\\\\' cause '\a' means something for windows.
Do not merge in master cause this is a modification only for Windows. Push it to another branch!