### PR TITLE
basicSync test path fix to work on windows

### DIFF
--- a/lib/test_basicSync.py
+++ b/lib/test_basicSync.py
@@ -64,7 +64,7 @@ testsets = []
 # create cartesian product of all test configurations
 for s in [1, 5000, 15000, 50000]:
   for t in [True, False]:
-      for p in [ "", "abc", "abc/abc", "abc/def/ghi" ]:
+      for p in [ "", os.path.normpath("abc"), os.path.normpath("abc/abc"), os.path.normpath("abc/def/ghi") ]:
           testsets.append( { 'basicSync_filesizeKB':s,
                              'basicSync_rmLocalStateDB':t,
                              'basicSync_subdirPath':p } )


### PR DESCRIPTION
used os.path.normpath to normalize path to work in every platform