### PR TITLE
labelling the tests as KnownBugs and FixedBugs

### DIFF
--- a/lib/test_basicSync.py
+++ b/lib/test_basicSync.py
@@ -21,6 +21,8 @@ from smashbox.utilities import *
 
 import glob
 
+config.expected_result = {"KnownBug":{"Platform":["Windows"],"Client":"all","Info":"Some tests cases are failing due to hardcode unix path / "}}
+
 filesizeKB = int(config.get('basicSync_filesizeKB',10000))
 
 # True => remove local sync db on the loser 

--- a/lib/test_concurrentDirMove.py
+++ b/lib/test_concurrentDirMove.py
@@ -6,7 +6,7 @@ all added files are kept on the server and are found in the final directory.
 
 """
 
-
+config.expected_result = {"KnownBug":{"Platform":["MacOsx"],"Client":"all","Info":"TO BE INVESTIGATED..."}}
 
 nfiles = int(config.get('concurrentMoveDir_nfiles',100))
 filesize = int(config.get('concurrentMoveDir_filesize',10))

--- a/lib/test_concurrentDirRemove.py
+++ b/lib/test_concurrentDirRemove.py
@@ -10,6 +10,7 @@ Cernbox/EOS: Hence the expected outcome is that part of the files that was alrea
 OwnCloud7? : For PUT which creates the missing directories the expected outcome is that all added files are kept on the server.
 
 """
+config.expected_result = {"KnownBug":{"Platform":["MacOsx"],"Client":"all","Info":"TO BE INVESTIGATED..."}}
 
 nfiles = int(config.get('concurrentRemoveDir_nfiles',10))
 filesizeKB = int(config.get('concurrentRemoveDir_filesizeKB',9000))

--- a/lib/test_concurrentOverwriteFile.py
+++ b/lib/test_concurrentOverwriteFile.py
@@ -33,6 +33,8 @@ import glob
 from smashbox.utilities import * 
 from smashbox.utilities import reflection
 
+config.expected_result = "FixedBug"
+
 @add_worker
 def worker0(step):
     shared = reflection.getSharedObject()

--- a/lib/test_dirDelete.py
+++ b/lib/test_dirDelete.py
@@ -7,6 +7,8 @@ __doc__ = """ This test creates a deeply nested directory structure and then rem
 
 import os.path
 
+config.expected_result = {"KnownBug":{"Platform":["MacOsx"],"Client":["2.2.4"],"Info":"TO BE INVESTIGATED ..."}}
+
 NESTING_LEVELS = config.get('dirDel_nestingLevels', 50)
 
 nfiles = int(config.get('dirDel_nfiles', 100))

--- a/lib/test_dirMove.py
+++ b/lib/test_dirMove.py
@@ -20,6 +20,8 @@ testsets = [ {'dirMove_DIRA':'DIRA',
 
 import os.path
 
+config.expected_result = "FixedBug"
+
 DIRA = os.path.normpath(config.get('dirMove_DIRA','DIRA'))
 DIRB = os.path.normpath(config.get('dirMove_DIRB','DIRB'))
 

--- a/lib/test_fileMove.py
+++ b/lib/test_fileMove.py
@@ -10,6 +10,8 @@ testsets = [ {'dirMove_DIRA':'DIRA',
 
 import os.path
 
+config.expected_result = "FixedBug"
+
 DIRA = os.path.normpath(config.get('dirMove_DIRA','DIRA'))
 DIRB = os.path.normpath(config.get('dirMove_DIRB','DIRB'))
 

--- a/lib/test_fileTinkerDownload.py
+++ b/lib/test_fileTinkerDownload.py
@@ -23,6 +23,8 @@ void OCC::SyncEngine::slotItemCompleted(const OCC::SyncFileItem&, const OCC::Pro
 from smashbox.utilities import *
 from smashbox.utilities.hash_files import *
 
+config.expected_result = "FixedBug"
+
 tinker_wait = int(config.get('fileTinkerDownload_tinker_wait',2))
 filesize = config.get('fileTinkerDownload_filesize',300000000)
 

--- a/lib/test_filenames.py
+++ b/lib/test_filenames.py
@@ -13,7 +13,9 @@ Notes:
 
 """
 
-filesizeKB = int(config.get('filenames_filesizeKB',1))
+expected_result = {"KnownBug":{"Platform":["Linux","MacOsx"],"Client":"all","Info":"TO BE INVESTIGATED ..."}}
+
+config.expected_result = int(config.get('filenames_filesizeKB',1))
 
 # see: mirall/csync/src/csync_exclude.c
 charsets_excluded_from_sync = {

--- a/lib/test_forbiddenFilenames.py
+++ b/lib/test_forbiddenFilenames.py
@@ -9,6 +9,8 @@ from smashbox.utilities import *
 from smashbox.utilities.hash_files import *
 from smashbox.utilities.monitoring import push_to_monitoring
 
+config.expected_result = "FixedBug"
+
 forbidden_charsets = {
 		'backslash' : '\\',
                  'colon' : ':',

--- a/lib/test_localDirRenameRecreate.py
+++ b/lib/test_localDirRenameRecreate.py
@@ -11,6 +11,7 @@ This follows from discussion in: https://github.com/owncloud/client/issues/3324
 TODO: a similar test for server side move.
 
 """
+config.expected_result = {"KnownBug":{"Platform":["MacOsx"],"Client":["2.3.3"],"Info":"TO BE INVESTIGATED ..."}}
 
 testsets = [ {'localDirRenameRecreate_DIRA':'DIRA', 
               'localDirRenameRecreate_DIRB':'DIRB',

--- a/lib/test_mtimes.py
+++ b/lib/test_mtimes.py
@@ -13,6 +13,8 @@ from smashbox.utilities import *
 from smashbox.utilities.hash_files import *
 from smashbox.utilities import reflection
 
+config.expected_result = {"KnownBug":{"Platform":"all","Client":["2.3.3","2.2.4"],"Info":"TO BE INVESTIGATED ..."}}
+
 sleep = int(config.get('mtimes_sleep',0)) 
 
 import random

--- a/lib/test_nplusone.py
+++ b/lib/test_nplusone.py
@@ -10,6 +10,8 @@ from smashbox.utilities import *
 from smashbox.utilities.hash_files import *
 from smashbox.utilities.monitoring import push_to_monitoring
 
+config.expected_result = "FixedBug"
+
 nfiles = int(config.get('nplusone_nfiles',10))
 filesize = config.get('nplusone_filesize',1000)
 

--- a/lib/test_nplustwo.py
+++ b/lib/test_nplustwo.py
@@ -8,6 +8,8 @@ __doc__ = """ Add nfiles to a directory (two clients) and check consistency afte
 from smashbox.utilities import *
 from smashbox.utilities.hash_files import *
 
+config.expected_result = "FixedBug"
+
 nfiles = int(config.get('nplustwo_nfiles',10))
 
 def adder(step):

--- a/lib/test_pingpong.py
+++ b/lib/test_pingpong.py
@@ -38,6 +38,8 @@ Logfile: test_pingpong/pong-ocsync.step02.cnt000.log
 
 """
 
+config.expected_result = {"KnownBug":{"Platform":"all","Client":["2.2.4","2.3.3"],"Info":"TO BE INVESTIGATED ..."}}
+
 filesizeKB = int(config.get('pingpong_filesizeKB',5000))
 pongdelay = float(config.get('pingpong_pongdelay',0))
 

--- a/lib/test_slowwrite.py
+++ b/lib/test_slowwrite.py
@@ -18,6 +18,8 @@ owncloudcmd will delay syncing of the file if the file is modified every 2 secon
 from smashbox.utilities import *
 from smashbox.utilities.hash_files import *
 
+config.expected_result = {"KnownBug":{"Platform":"all","Client":"all","Info":"TO BE INVESTIGATED ..."}}
+
 MB = 1024*1000
 
 filesizeKB = int(config.get('slowwrite_filesizeKB',10000))

--- a/lib/test_storm.py
+++ b/lib/test_storm.py
@@ -9,6 +9,8 @@ __doc__ = """ Each of nuploaders creates nfiles and syncs them at the same time 
 from smashbox.utilities import *
 from smashbox.utilities.hash_files import *
 
+config.expected_result = {"KnownBug":{"Platform":"all","Client":["2.2.4","2.3.3"],"Info":"TO BE INVESTIGATED ..."}}
+
 # Files created by each uploader
 nfiles = int(config.get('storm_nfiles',10))
 

--- a/lib/test_unicodejam.py
+++ b/lib/test_unicodejam.py
@@ -9,6 +9,8 @@ __doc__ = """ Add 1 (n) files to a directory (1 client) and check consistency ac
 from smashbox.utilities import *
 from smashbox.utilities.hash_files import *
 
+config.expected_result = "FixedBug"
+
 nfiles = 10
 
 def removeunicodejam(localdir):

--- a/lib/test_userload.py
+++ b/lib/test_userload.py
@@ -6,6 +6,7 @@ import tempfile
 __doc__ = """ One uploader, n downloaders. Uploader creates nfiles and syncs them at the same time to the same account. The checker verifies integrity of files and completness of sync. 
 """
 
+config.expected_result = {"KnownBug":{"Platform":["Linux","MacOsx"],"Client":["2.1.1","2.2.4"],"Info":"TO BE INVESTIGATED ..."}}
 
 # Files created by the uploader
 nfiles = int(config.get('userload_nfiles',5))

--- a/python/smashbox/monitoring/kibana_monitoring.py
+++ b/python/smashbox/monitoring/kibana_monitoring.py
@@ -22,14 +22,28 @@ class StateMonitor:
         self.test_results = dict()
         self.runtimestamp = config._run_timestamp
 
-        # extract test parameters
+        # extract test parameters and labelling
         parameters = []
         param = {}
+        label_expected_result = ""
+        info_expected_result = ""
         for c in config.__dict__:
             if c.startswith(testname + "_"):
                 param[str((c.replace(testname + "_", "")))] = config[c]
                 parameters.append(param)
                 print c, config[c]
+
+        oc_client_version = str(str(ocsync_version())[1:-1].replace(", ", "."))
+
+
+        if config['expected_result'] == "FixedBug":
+            label_expected_result = config['expected_result']
+        else:
+            if platform.system() in config['expected_result']['KnownBug']['Platform'] and (oc_client_version in config['expected_result']['KnownBug']['Client'] or config['expected_result']['KnownBug']['Client']=="all"):
+                label_expected_result = "KnownBug"
+                info_expected_result = config['expected_result']["KnownBug"]["Info"]
+            else:
+                label_expected_result = "FixedBug"
 
         if platform.system() == 'Linux':
             distribution = platform.dist()
@@ -44,9 +58,9 @@ class StateMonitor:
 
         # initialize json to be sent for monitoring
         self.test_results = {"activity": config.kibana_activity, 'test_name': testname, 'hostname': socket.gethostname(),
-                             'oc_client_version': str(str(ocsync_version())[1:-1].replace(", ",".")),'oc_server': config.oc_server.split("/")[0],'platform': client_platform,
+                             'oc_client_version': oc_client_version ,'oc_server': config.oc_server.split("/")[0],'platform': client_platform,
                              'parameters':parameters,'parameters_text':str(parameters),'errors': [],'errors_text': "",'success': [],
-                             'total_errors':0,'total_success':0, 'qos_metrics': [],'passed': 0,'failed': 0 }
+                             'total_errors':0,'total_success':0, 'qos_metrics': [],'passed': 0,'failed': 0, 'label_expected_result': label_expected_result, 'info_expected_result':info_expected_result }
 
 
     def join_worker_results(self):


### PR DESCRIPTION
Now we can filter in Kibana with these labels the tests that are failing ( KnowBugs). Filtering tests with FixedBugs should give a dashboard green (no failed tests), if something becomes "red" then it is a UnknownBug ( this is not automated )  the user should go to smashbox understand why is giving a "red value" and change the value to UnknownBug or KnownBug. 

KnownBug: The bug is understood by the user/tester. The bug is reported but it needs still to be fixed / Maybe we can add as info: ( under discussion / development ... ) . 

UnknownBug: The bug is NOT  fully understood by the user/tester. The bug needs to be investigated.

FixedBug: The bug is fixed we just run the test to be sure that this bug is fully fixed and it is not appearing again.


So the normal pipeline of the a user/tester using smashbox and the dashboard is:

   -->  (1) FixedBug --> (2) UnknownBug --> (3) KnownBug --> (4) FixedBug -->

This pipeline is explained by the following situations:

----> Use Case 1:  The user/tester finds/suspects a bug and use smashbox to develop a test and report it 

(1) The user/tester develop a test  and report the test  -->(3) KnownBug. 
(2) The user/tester track the behaviour of the test with new client versions  to know if the bug is fixed or not --> (4) FixedBug

  (3) KnownBug --> (4) FixedBug 

----> Use Case 2 : A test starts to fail

(1) A FixedBug starts to fail --> (2) UnknowBug
(2) The user/tester needs to investigate the cause of the failure and fixed the test accordingly. Then it goes to the Use Case 1  and it goes to (3) KnownBug --> (4) FixedBug

-------

Looking the pipeline I propose to automate the transition of the states (changing the labels) and send a alarm to the user/tester with a message:

 "Smashbox requires user/tester internvention cause: UnknowBug --> KnownBug in Test: nplusone, Platform: Windows, Client: "2.3.3", Error: "nfiles should be x". 

This is just to make easier the monitoring of test results but the dashboard should show the same.




