### PR TITLE
change bash script to run all nplusone tests through fuse to avoid pile ups

### DIFF
--- a/corruption_test/run_all_fuse
+++ b/corruption_test/run_all_fuse
@@ -20,4 +20,4 @@ kinit ccboxtest@CERN.CH -k -t /etc/cboxtest.keytab
 /usr/bin/eosfusebind
 /root/smashbox/corruption_test/run_nplusone_fuse 1 eoshome-04 &>> /var/log/sls/cboxsls-eoshome-04-fuse.log
 
-kdestroy
+kdestroy &> /dev/null

--- a/corruption_test/run_all_fuse
+++ b/corruption_test/run_all_fuse
@@ -2,22 +2,22 @@
 
 kinit dcboxtest@CERN.CH -k -t /etc/cboxtest.keytab
 /usr/bin/eosfusebind
-/usr/bin/sh -c 'exec /usr/bin/nohup /root/smashbox/corruption_test/run_nplusone_fuse 1 eoshome-00 &>> /var/log/sls/cboxsls-eoshome-00-fuse.log'
+/root/smashbox/corruption_test/run_nplusone_fuse 1 eoshome-00 &>> /var/log/sls/cboxsls-eoshome-00-fuse.log
 
 kinit acboxtest@CERN.CH -k -t /etc/cboxtest.keytab
 /usr/bin/eosfusebind
-/usr/bin/sh -c 'exec /usr/bin/nohup /root/smashbox/corruption_test/run_nplusone_fuse 1 eoshome-01 &>> /var/log/sls/cboxsls-eoshome-01-fuse.log'
+/root/smashbox/corruption_test/run_nplusone_fuse 1 eoshome-01 &>> /var/log/sls/cboxsls-eoshome-01-fuse.log
 
 kinit hcboxtest@CERN.CH -k -t /etc/cboxtest.keytab
 /usr/bin/eosfusebind
-/usr/bin/sh -c 'exec /usr/bin/nohup /root/smashbox/corruption_test/run_nplusone_fuse 1 eoshome-02 &>> /var/log/sls/cboxsls-eoshome-02-fuse.log'
+/root/smashbox/corruption_test/run_nplusone_fuse 1 eoshome-02 &>> /var/log/sls/cboxsls-eoshome-02-fuse.log
 
 kinit bcboxtest@CERN.CH -k -t /etc/cboxtest.keytab
 /usr/bin/eosfusebind
-/usr/bin/sh -c 'exec /usr/bin/nohup /root/smashbox/corruption_test/run_nplusone_fuse 1 eoshome-03 &>> /var/log/sls/cboxsls-eoshome-03-fuse.log'
+/root/smashbox/corruption_test/run_nplusone_fuse 1 eoshome-03 &>> /var/log/sls/cboxsls-eoshome-03-fuse.log
 
 kinit ccboxtest@CERN.CH -k -t /etc/cboxtest.keytab
 /usr/bin/eosfusebind
-/usr/bin/sh -c 'exec /usr/bin/nohup /root/smashbox/corruption_test/run_nplusone_fuse 1 eoshome-04 &>> /var/log/sls/cboxsls-eoshome-04-fuse.log'
+/root/smashbox/corruption_test/run_nplusone_fuse 1 eoshome-04 &>> /var/log/sls/cboxsls-eoshome-04-fuse.log
 
 kdestroy

--- a/corruption_test/run_all_fuse
+++ b/corruption_test/run_all_fuse
@@ -20,4 +20,4 @@ kinit ccboxtest@CERN.CH -k -t /etc/cboxtest.keytab
 /usr/bin/eosfusebind
 /root/smashbox/corruption_test/run_nplusone_fuse 1 eoshome-04 &>> /var/log/sls/cboxsls-eoshome-04-fuse.log
 
-kdestroy &> /dev/null
+kdestroy


### PR DESCRIPTION
change bash script to run all nplusone tests through fuse to avoid pile ups when a process hangs