### PR TITLE
add try/catch on file not found and file exists exceptions while deleting/creating workdir

### DIFF
--- a/python/smashbox/utilities/__init__.py
+++ b/python/smashbox/utilities/__init__.py
@@ -489,13 +489,28 @@ def sleep(n):
 def mkdir(d):
     logger.info('mkdir %s',d)
     if not os.path.exists(d):
-        os.makedirs(d)
+        try:
+            os.makedirs(d)
+        except OSError,x:
+            import errno
+            if x.errno == errno.EEXIST:
+                logger.warning(x)
+            else:
+                raise
+
     return d
 
 
 def remove_tree(path):
     logger.info('remove directory tree %s',path)
-    shutil.rmtree(path)
+    try:
+        shutil.rmtree(path)
+    except OSError,x:
+        import errno
+        if x.errno == errno.ENOENT:
+            logger.warning(x)
+        else:
+            raise
 
 
 def remove_file(path):
@@ -504,7 +519,6 @@ def remove_file(path):
         os.remove(path)
     except OSError,x:
         import errno
-
         if x.errno == errno.ENOENT:
             logger.warning(x)
         else:


### PR DESCRIPTION
Fixes nplustwo test.

Race condition between worker0 and worker1 would cause one of the processes to crash while trying to remove an already deleted working directory, or create an already existing directory.